### PR TITLE
Nokogiri security update to 1.8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'nokogiri', '1.8.1'
 gem 'rails', '4.2.7.1'
 gem 'mysql2', '>= 0.3.13', '< 0.5'
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   mysql2 (>= 0.3.13, < 0.5)
+  nokogiri (= 1.8.1)
   rails (= 4.2.7.1)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)


### PR DESCRIPTION
Addresses security issue [reported by Github](https://github.com/blog/2470-introducing-security-alerts-on-github) to get rid of pesky notification.

@miketineo 